### PR TITLE
refactor(cli): migrate to urfave/cli v2 for command parsing

### DIFF
--- a/container-runtime/cmd/mrunc/lets.go
+++ b/container-runtime/cmd/mrunc/lets.go
@@ -1,19 +1,14 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "my-capstone-project/internal/cli"
+	"fmt"
+	"my-capstone-project/internal/cli"
+	"os"
 )
 
 func main() {
-    if len(os.Args) < 2 {
-        fmt.Println("Usage: mrunc <command> [args...]")
-        os.Exit(1)
-    }
-    
-    if err := cli.Execute(); err != nil {
-        fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-        os.Exit(1)
-    }
+	if err := cli.NewApp().Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/container-runtime/go.mod
+++ b/container-runtime/go.mod
@@ -4,4 +4,13 @@ go 1.23.0
 
 toolchain go1.24.6
 
-require golang.org/x/sys v0.35.0 // indirect
+require (
+	github.com/urfave/cli/v2 v2.27.5
+	golang.org/x/sys v0.35.0
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
+)

--- a/container-runtime/go.sum
+++ b/container-runtime/go.sum
@@ -1,2 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
+github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
+github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/container-runtime/internal/cli/child.go
+++ b/container-runtime/internal/cli/child.go
@@ -1,45 +1,39 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"my-capstone-project/internal/runtime"
 	"my-capstone-project/internal/utils"
 	"my-capstone-project/pkg/specs"
-	"strconv"
 	"os"
-	"io"
-	"encoding/json"
+	"strconv"
 	"syscall"
+
+	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
 )
 
-func childCommand() error {
-	
+func childCommand(ctx *cli.Context) error {
 	config, err := receiveConfigFromPipe()
 	if err != nil {
-        return fmt.Errorf("child: failed to receive config: %v", err)
-    }
-	// container_id, errstr := utils.RandomHexString(16)
-	// if errstr != nil {
-	// 	return fmt.Errorf("failed to generate random hex strings for container ID: %v", errstr)
-	// }
-
-
+		return fmt.Errorf("child: failed to receive config: %v", err)
+	}
 
 	if !config.Process.Terminal {
-        fmt.Printf("Non-interactive mode: detaching from terminal\n")
-        if _, err := syscall.Setsid(); err != nil && err != syscall.EPERM {
-            fmt.Printf("Warning: setsid failed: %v\n", err)
-        }
-    } else {
-        fmt.Printf("Interactive mode: keeping terminal connection\n")
-    }
-    
+		fmt.Printf("Non-interactive mode: detaching from terminal\n")
+		if _, err := syscall.Setsid(); err != nil && err != syscall.EPERM {
+			fmt.Printf("Warning: setsid failed: %v\n", err)
+		}
+	} else {
+		fmt.Printf("Interactive mode: keeping terminal connection\n")
+	}
+
 	// Set hostname
 	if err := syscall.Sethostname([]byte(config.Hostname)); err != nil {
 		return fmt.Errorf("failed to set hostname: %v", err)
 	}
-
 
 	root_fs := config.RootFS.Path
 	root_fs_putold := config.RootFS.Path + "/put_old"
@@ -48,14 +42,17 @@ func childCommand() error {
 	if err := unix.Mount(root_fs, root_fs, "", unix.MS_BIND, ""); err != nil {
 		panic(fmt.Errorf("bind mount failed: %w", err))
 	}
+
 	// Pivot root
 	if err := runtime.PivotRoot(root_fs, root_fs_putold); err != nil {
 		return fmt.Errorf("failed to pivot root: %v", err)
 	}
+
 	workDir := config.Process.Cwd
 	if workDir == "" {
 		workDir = "/"
 	}
+
 	// Change to root directory
 	if err := syscall.Chdir(workDir); err != nil {
 		return fmt.Errorf("failed to chdir: %v", err)
@@ -74,7 +71,6 @@ func childCommand() error {
 	if len(config.Process.Env) > 0 {
 		os.Clearenv()
 		for _, env := range config.Process.Env {
-			// env is in format "KEY=VALUE"
 			if err := os.Setenv(utils.ParseEnvKey(env), utils.ParseEnvValue(env)); err != nil {
 				return fmt.Errorf("failed to set environment: %v", err)
 			}
@@ -82,47 +78,45 @@ func childCommand() error {
 	}
 
 	if err := runtime.SetProcessUser(config.Process.User); err != nil {
-        return fmt.Errorf("failed to set process user: %v", err)
-    }
+		return fmt.Errorf("failed to set process user: %v", err)
+	}
 
 	// Execute the process (replace current process)
 	command := config.Process.Args[0]
 	args := config.Process.Args
 	env := os.Environ()
 
-
 	return runtime.ExecuteCommand(command, args, env)
 }
 
 // receiveConfigFromPipe reads configuration from pipe passed by parent
 func receiveConfigFromPipe() (*specs.ContainerConfig, error) {
-    // Get pipe FD from environment variable
-    pipeFdStr := os.Getenv("_MRUNC_PIPE_FD")
-    if pipeFdStr == "" {
-        return nil, fmt.Errorf("_MRUNC_PIPE_FD environment variable not set")
-    }
+	// Get pipe FD from environment variable
+	pipeFdStr := os.Getenv("_MRUNC_PIPE_FD")
+	if pipeFdStr == "" {
+		return nil, fmt.Errorf("_MRUNC_PIPE_FD environment variable not set")
+	}
 
-    pipeFd, err := strconv.Atoi(pipeFdStr)
-    if err != nil {
-        return nil, fmt.Errorf("invalid pipe FD: %v", err)
-    }
+	pipeFd, err := strconv.Atoi(pipeFdStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pipe FD: %v", err)
+	}
 
-    // Create file from FD
-    pipe := os.NewFile(uintptr(pipeFd), "config-pipe")
-    defer pipe.Close()
+	// Create file from FD
+	pipe := os.NewFile(uintptr(pipeFd), "config-pipe")
+	defer pipe.Close()
 
-    // Read all data from pipe
-    configData, err := io.ReadAll(pipe)
-    if err != nil {
-        return nil, fmt.Errorf("failed to read config data: %v", err)
-    }
+	// Read all data from pipe
+	configData, err := io.ReadAll(pipe)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config data: %v", err)
+	}
 
-    // Deserialize config
-    var config specs.ContainerConfig
-    if err := json.Unmarshal(configData, &config); err != nil {
-        return nil, fmt.Errorf("failed to parse config JSON: %v", err)
-    }
+	// Deserialize config
+	var config specs.ContainerConfig
+	if err := json.Unmarshal(configData, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config JSON: %v", err)
+	}
 
-    return &config, nil
+	return &config, nil
 }
-

--- a/container-runtime/internal/cli/commands.go
+++ b/container-runtime/internal/cli/commands.go
@@ -1,37 +1,29 @@
 package cli
 
 import (
-    "fmt"
-    "os"
+	"github.com/urfave/cli/v2"
 )
 
-func Execute() error {
-     if len(os.Args) < 2 {
-        return showUsage()
-    }
-    switch os.Args[1] {
-    case "run":
-        return runCommand()
-    case "child":
-        return childCommand()
-    // case "create":
-    //     return createCommand()
-    // case "start":
-    //     return startCommand()
-    // case "stop":
-    //     return stopCommand()
-    // case "delete":
-    //     return deleteCommand()
-    default:
-        return fmt.Errorf("unknown command: %s", os.Args[1])
-    }
-}
+const Version = "0.1.1"
 
-func showUsage() error {
-    fmt.Println("Usage:")
-    fmt.Println("  mrunc run <config.json>")
-    fmt.Println("")
-    fmt.Println("Examples:")
-    fmt.Println("  mrunc run configs/examples/ubuntu-container.json")
-    return nil
+func NewApp() *cli.App {
+	return &cli.App{
+		Name:    "mrunc",
+		Usage:   "A minimal container runtime",
+		Version: Version,
+		Commands: []*cli.Command{
+			{
+				Name:      "run",
+				Usage:     "Run a container from a config file",
+				ArgsUsage: "<config.json>",
+				Action:    runCommand,
+			},
+			{
+				Name:   "child",
+				Usage:  "Internal command for child process (do not call directly)",
+				Hidden: true,
+				Action: childCommand,
+			},
+		},
+	}
 }

--- a/container-runtime/internal/cli/run.go
+++ b/container-runtime/internal/cli/run.go
@@ -1,70 +1,76 @@
 package cli
 
 import (
-    "fmt"
-    "os"
-    "os/exec"
-	"my-capstone-project/internal/runtime"
+	"encoding/json"
+	"fmt"
 	"my-capstone-project/internal/container"
-    "encoding/json"
+	"my-capstone-project/internal/runtime"
+	"os"
+	"os/exec"
+
+	"github.com/urfave/cli/v2"
 )
 
-func runCommand() error {
-    if len(os.Args) < 3 {
-        return fmt.Errorf("usage: mrunc run <config.json>")
-    }
-	configPath := os.Args[2]
-    config, err := container.LoadConfig(configPath)
-    if err != nil {
-        return err
-    }
-    childPipe,parentPipe ,err := os.Pipe()
-    if err != nil {
-        return fmt.Errorf("failed to create pipe: %v", err)
-    }
-    configData, err := json.Marshal(config)
-    if err != nil {
-        return err
-    }
+func runCommand(ctx *cli.Context) error {
+	if ctx.NArg() < 1 {
+		return fmt.Errorf("usage: mrunc run <config.json>")
+	}
 
+	configPath := ctx.Args().Get(0)
+	config, err := container.LoadConfig(configPath)
+	if err != nil {
+		return err
+	}
 
-    cmd := exec.Command("/proc/self/exe", append([]string{"child"}, os.Args[2:]...)...)
-    cmd.ExtraFiles = []*os.File{childPipe}
-    if config.Process.Terminal {
-        // Interactive mode - connect to terminal
-        fmt.Printf("Starting container in interactive mode\n")
-        cmd.Stdin = os.Stdin
-        cmd.Stdout = os.Stdout
-        cmd.Stderr = os.Stderr
-    } else {
-        // Non-interactive mode - disconnect from terminal
-        fmt.Printf("Starting container in non-interactive mode\n")
-        cmd.Stdin = nil  // No stdin
-        cmd.Stdout = os.Stdout  // Still show output (or redirect to logs)
-        cmd.Stderr = os.Stderr  // Still show errors (or redirect to logs)
-    }
-    cmd.Env = append(os.Environ(), "_MRUNC_PIPE_FD=3")
-    cmd.SysProcAttr = runtime.CreateNamespaces()
-    
-    if err := cmd.Start(); err != nil {
-        // Clean up on error
-        parentPipe.Close()
-        childPipe.Close()
-        return err
-    }
-    childPipe.Close()
-    _, err = parentPipe.Write(configData)
+	childPipe, parentPipe, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("failed to create pipe: %v", err)
+	}
 
-    if err != nil {
-        parentPipe.Close()
-        return fmt.Errorf("failed to send config: %v", err)
-    }
-    parentPipe.Close()
+	configData, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
 
-    if err := cmd.Wait(); err != nil {
-        fmt.Printf("PARENT: Child exited with error: %v\n", err)
-    } else {
-        fmt.Println("PARENT: Child completed successfully")
-    }
-    return nil
+	cmd := exec.Command("/proc/self/exe", append([]string{"child"}, os.Args[2:]...)...)
+	cmd.ExtraFiles = []*os.File{childPipe}
+
+	if config.Process.Terminal {
+		// Interactive mode - connect to terminal
+		fmt.Printf("Starting container in interactive mode\n")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	} else {
+		// Non-interactive mode - disconnect from terminal
+		fmt.Printf("Starting container in non-interactive mode\n")
+		cmd.Stdin = nil
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
+	cmd.Env = append(os.Environ(), "_MRUNC_PIPE_FD=3")
+	cmd.SysProcAttr = runtime.CreateNamespaces()
+
+	if err := cmd.Start(); err != nil {
+		parentPipe.Close()
+		childPipe.Close()
+		return err
+	}
+
+	childPipe.Close()
+	_, err = parentPipe.Write(configData)
+	if err != nil {
+		parentPipe.Close()
+		return fmt.Errorf("failed to send config: %v", err)
+	}
+	parentPipe.Close()
+
+	if err := cmd.Wait(); err != nil {
+		fmt.Printf("PARENT: Child exited with error: %v\n", err)
+	} else {
+		fmt.Println("PARENT: Child completed successfully")
+	}
+
+	return nil
 }


### PR DESCRIPTION
- replace custom argument handling with urfave/cli App
- refactor runCommand and childCommand to use *cli.Context
- add NewApp() with run and child commands
- update go.mod and go.sum with urfave/cli dependencies
- simplify main entrypoint to use cli.NewApp().Run()